### PR TITLE
logging naming convention hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ export DEBUG_I2P=warn
 export DEBUG_I2P=error
 ```
 
-If in case I2P_DEBUG is set to an unrecognized variable, it will fall back to "debug".
+If I2P_DEBUG is set to an unrecognized variable, it will fall back to "debug".

--- a/log.go
+++ b/log.go
@@ -13,7 +13,7 @@ var (
 	once sync.Once
 )
 
-func InitializeLogger() {
+func InitializeI2PKeysLogger() {
 	once.Do(func() {
 		log = logrus.New()
 		// We do not want to log by default
@@ -37,14 +37,14 @@ func InitializeLogger() {
 	})
 }
 
-// GetLogger returns the initialized logger
-func GetLogger() *logrus.Logger {
+// GetI2PKeysLogger returns the initialized logger
+func GetI2PKeysLogger() *logrus.Logger {
 	if log == nil {
-		InitializeLogger()
+		InitializeI2PKeysLogger()
 	}
 	return log
 }
 
 func init() {
-	InitializeLogger()
+	InitializeI2PKeysLogger()
 }


### PR DESCRIPTION
There is a naming collision that conflicts with the same logging paradigm found in go-i2p and sam3. So we require renaming the logger functions in order for the libs to work together.