### PR TITLE
return os.ErrNotExist instead of written error

### DIFF
--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -88,7 +88,7 @@ func LoadKeys(r string) (I2PKeys, error) {
 	}
 	if !exists {
 		log.WithError(err).Error("File does not exist")
-		return I2PKeys{}, fmt.Errorf("file does not exist: %s", r)
+		return I2PKeys{}, os.ErrNotExist
 	}
 	fi, err := os.Open(r)
 	if err != nil {


### PR DESCRIPTION
This would allow for a more portable error for keys not existing.