### PR TITLE
Refactored LoadKeysIncompat & Finished up LoadKeys()

### DIFF
--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -62,18 +62,25 @@ func fileExists(filename string) (bool, error) {
 	return !info.IsDir(), nil
 }
 
-// load keys from non standard format
-func LoadKeysIncompat(r io.Reader) (k I2PKeys, err error) {
+func LoadKeysIncompat(r io.Reader) (I2PKeys, error) {
 	log.Debug("Loading keys from reader")
 	var buff bytes.Buffer
-	_, err = io.Copy(&buff, r)
-	if err == nil {
-		parts := strings.Split(buff.String(), "\n")
-		k = I2PKeys{I2PAddr(parts[0]), parts[1]}
-		log.WithField("keys", k).Debug("Loaded keys")
+	_, err := io.Copy(&buff, r)
+	if err != nil {
+		log.WithError(err).Error("Error copying from reader, did not load keys")
+		return I2PKeys{}, fmt.Errorf("error copying from reader: %w", err)
 	}
-	log.WithError(err).Error("Error copying from reader, did not load keys")
-	return
+
+	parts := strings.Split(buff.String(), "\n")
+	if len(parts) < 2 {
+		err := errors.New("invalid key format: not enough data")
+		log.WithError(err).Error("Error parsing keys")
+		return I2PKeys{}, err
+	}
+
+	k := I2PKeys{I2PAddr(parts[0]), parts[1]}
+	log.WithField("keys", k).Debug("Loaded keys")
+	return k, nil
 }
 
 // load keys from non-standard format by specifying a text file.

--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -62,6 +62,7 @@ func fileExists(filename string) (bool, error) {
 	return !info.IsDir(), nil
 }
 
+// LoadKeysIncompat loads keys from non-standard format
 func LoadKeysIncompat(r io.Reader) (I2PKeys, error) {
 	log.Debug("Loading keys from reader")
 	var buff bytes.Buffer

--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -62,7 +62,7 @@ func fileExists(filename string) (bool, error) {
 	return !info.IsDir(), nil
 }
 
-// LoadKeysIncompat loads keys from non-standard format
+// LoadKeysIncompat loads keys from a non-standard format
 func LoadKeysIncompat(r io.Reader) (I2PKeys, error) {
 	log.Debug("Loading keys from reader")
 	var buff bytes.Buffer

--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -87,8 +87,20 @@ func LoadKeys(r string) (I2PKeys, error) {
 		return I2PKeys{}, err
 	}
 	if !exists {
-		log.WithError(err).Error("File does not exist")
-		return I2PKeys{}, os.ErrNotExist
+		// File doesn't exist so we'll generate new keys
+		log.WithError(err).Debug("File does not exist, attempting to generate new keys")
+		k, err := NewDestination()
+		if err != nil {
+			log.WithError(err).Error("Error generating new keys")
+			return I2PKeys{}, err
+		}
+		// Save the new keys to the file
+		err = StoreKeys(*k, r)
+		if err != nil {
+			log.WithError(err).Error("Error saving new keys to file")
+			return I2PKeys{}, err
+		}
+		return *k, nil
 	}
 	fi, err := os.Open(r)
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ export DEBUG_I2P=warn
 export DEBUG_I2P=error
 ```
 
-If I2P_DEBUG is set to an unrecognized variable, it will fall back to "debug".
+If DEBUG_I2P is set to an unrecognized variable, it will fall back to "debug".


### PR DESCRIPTION
Previously had faulty error handling including printing an error when the keys were actually loaded.

Also made it so that LoadKeys() generates new keys if the file doesn't exist.