### PR TITLE
return error instead of panic when VALUE= is not found

### DIFF
--- a/I2PAddr_test.go
+++ b/I2PAddr_test.go
@@ -317,3 +317,12 @@ func Test_KeyStorageAndLoading(t *testing.T) {
 		}
 	})
 }
+
+func Test_BasicInvalidAddress(t *testing.T) {
+	invalidAddr := strings.Repeat("x", 60)
+	invalidAddr += ".b32.i2p"
+	_, err := Lookup(invalidAddr)
+	if err == nil {
+		t.Fatal("Expected error for nonexistent address")
+	}
+}

--- a/Lookup.go
+++ b/Lookup.go
@@ -47,7 +47,12 @@ func Lookup(addr string) (*I2PAddr, error) {
 		if n < 1 {
 			return nil, fmt.Errorf("no destination data received")
 		}
-		value := strings.Split(string(buf[:n]), "VALUE=")[1]
+		parts := strings.Split(string(buf[:n]), "VALUE=")
+		if len(parts) < 2 {
+			log.Error("Could not find VALUE=, could not find destination?")
+			return nil, fmt.Errorf("could not find VALUE=")
+		}
+		value := parts[1]
 		addr, err := NewI2PAddrFromString(value)
 		if err != nil {
 			log.Error("Failed to parse I2P address from lookup response")

--- a/Lookup.go
+++ b/Lookup.go
@@ -49,7 +49,7 @@ func Lookup(addr string) (*I2PAddr, error) {
 		}
 		parts := strings.Split(string(buf[:n]), "VALUE=")
 		if len(parts) < 2 {
-			log.Error("Could not find VALUE=, could not find destination?")
+			log.Error("Could not find VALUE=, maybe we couldn't find the destination?")
 			return nil, fmt.Errorf("could not find VALUE=")
 		}
 		value := parts[1]

--- a/Makefile
+++ b/Makefile
@@ -109,10 +109,13 @@ test-key-storage-incompat:
 test-key-storage-nonexistent:
 	go test -v -run Test_KeyStorageAndLoading/LoadNonexistentFile
 
+test-basic-invalid-address:
+	go test -v -run Test_BasicInvalidAddress
+
 # Aggregate targets
 test-all:
 	go test -v ./...
 
 test-subtests: test-newi2paddrfromstring-valid test-newi2paddrfromstring-invalid test-newi2paddrfromstring-base32 test-newi2paddrfromstring-empty test-newi2paddrfromstring-i2p-suffix test-i2paddr-base32-suffix test-i2paddr-base32-length test-desthashfromstring-valid test-desthashfromstring-invalid test-desthashfromstring-empty test-i2paddr-to-bytes-roundtrip test-i2paddr-to-bytes-comparison test-key-generation-and-handling-loadkeys test-key-generation-and-handling-storekeys-incompat test-key-generation-and-handling-storekeys test-key-storage-file test-key-storage-incompat test-key-storage-nonexistent
 
-test: test-basic test-basic-lookup test-newi2paddrfromstring test-i2paddr test-desthashfromstring test-i2paddr-to-bytes test-key-generation-and-handling test-key-storage test-subtests test-all
+test: test-basic test-basic-lookup test-newi2paddrfromstring test-i2paddr test-desthashfromstring test-i2paddr-to-bytes test-key-generation-and-handling test-key-storage test-basic-invalid-address test-subtests test-all


### PR DESCRIPTION
Before, if VALUE= was not found. Lookup would panic with:
panic: runtime error: index out of range [1] with length 1

You can test this by using the previous code and trying to find a destination that does not exist, it would panic.